### PR TITLE
Fix the problem on lineToPrint length count

### DIFF
--- a/Word.java
+++ b/Word.java
@@ -3,99 +3,39 @@ import java.util.StringTokenizer;
 
 public class Word {
 
-    public static void main(String[] args) throws FileNotFoundException {
+    public static void main(String[] args) throws IOException {
 
         // USACO 2020 January Contest, Bronze
         // Problem 1. Word Processor
 
         // link: http://www.usaco.org/index.php?page=viewproblem2&cpid=987
 
-        Kattio io = new Kattio("word");
+        BufferedReader br = new BufferedReader(new FileReader("word.in"));
+        PrintWriter pw = new PrintWriter("word.out");
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        int n = Integer.parseInt(st.nextToken());
+        int k = Integer.parseInt(st.nextToken());
+        String[] essayArray = br.readLine().split(" ");
 
-        int n = io.nextInt();
-        int k = io.nextInt();
-        String essay = io.nextLine();
-        String[] essayArray = essay.split(" ");
+        String lineToPrint = essayArray[0];
+        String nextWord;
+        int currentLength = lineToPrint.length();
 
-        //new
-        String lineToPrint = "";
-
-        for (String nextWord : essayArray) {
-//            String lineToPrint = "";
-            //new
-            if (lineToPrint.length() + nextWord.length() <= k) {
-                if (lineToPrint.length() == 0) {
-                    lineToPrint = nextWord;
-                } else {
-                    lineToPrint = lineToPrint + " " + nextWord;
-                }
+        for (int i=1; i<n; i++) {
+            nextWord = essayArray[i];
+            if (currentLength + nextWord.length() <= k) {
+                lineToPrint = lineToPrint + " " + nextWord;
+                currentLength += nextWord.length();
             } else {
-                io.println(lineToPrint);
+                pw.println(lineToPrint);
                 lineToPrint = nextWord;
+                currentLength = lineToPrint.length();
             }
 
         }
-        io.println(lineToPrint);
+        pw.print(lineToPrint);
 
-
-        io.close();
-
-
+        pw.close();
     }
-
-}
-
-class Kattio extends PrintWriter {
-    private final BufferedReader r;
-    private StringTokenizer st;
-
-    // standard input.in
-    public Kattio() {
-        this(System.in, System.out);
-    }
-
-    public Kattio(InputStream i, OutputStream o) {
-        super(o);
-        r = new BufferedReader(new InputStreamReader(i));
-    }
-
-    // USACO-style file input.in
-    public Kattio(String problemName) throws FileNotFoundException {
-        super(problemName + ".out");
-        r = new BufferedReader(new FileReader(problemName + ".in"));
-    }
-
-    // return null if no more input line
-    public String nextLine() {
-        try {
-            return r.readLine();
-        } catch (IOException e) {
-        }
-        return null;
-    }
-
-    // returns null if no more input.in
-    public String next() {
-        try {
-            while (st == null || !st.hasMoreTokens())
-                st = new StringTokenizer(r.readLine());
-            return st.nextToken();
-        } catch (IOException e) {
-        }
-        return null;
-    }
-
-    public int nextInt() {
-        return Integer.parseInt(next());
-    }
-
-    public double nextDouble() {
-        return Double.parseDouble(next());
-    }
-
-    public long nextLong() {
-        return Long.parseLong(next());
-    }
-
 
 }


### PR DESCRIPTION
Please note "currentLength" was added to track the "real" length of the line. lineToPrint.length() != currentLength, as space was added on the line to separate two words.